### PR TITLE
Update README with new installation command and note for older versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ddev add-on get Morgy93/ddev-deno
 ddev restart
 ```
 
-> **Note**
+> [!NOTE]
 > For older versions of DDEV (prior to v1.23.5), use `ddev get` instead of `ddev add-on get`.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ YouTube: [What is Deno?](https://www.youtube.com/watch?v=KPTOo4k8-GE)
 ## Installation
 
 ```shell
-ddev get Morgy93/ddev-deno
+ddev add-on get Morgy93/ddev-deno
 ddev restart
 ```
+
+> **Note**
+> For older versions of DDEV (prior to v1.23.5), use `ddev get` instead of `ddev add-on get`.
 
 ## Usage
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -26,8 +26,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   ddev restart
   health_checks
 }
@@ -35,9 +35,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ${DDEV_ADDON} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DDEV_ADDON}
+  echo "# ddev add-on get ${DDEV_ADDON} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DDEV_ADDON}
   ddev restart >/dev/null
   health_checks
 }
-


### PR DESCRIPTION
Update the installation command and tests to use `ddev add-on get` instead of `ddev get`.

* **README.md**
  - Update the installation command to use `ddev add-on get Morgy93/ddev-deno`.
  - Add a note for older versions to use `ddev get` instead of `ddev add-on get`.

* **tests/test.bats**
  - Update the test cases to use `ddev add-on get` instead of `ddev get`.

