### PR TITLE
Pin third-party action to commit SHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ddev/github-action-add-on-test@v2
+      - uses: ddev/github-action-add-on-test@<commit-sha>
         with:
           ddev_version: ${{ matrix.ddev_version }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <h1 align="center">ddev-deno</h1>
 </div>
 
-[![tests](https://github.com/OpenForgeProject/ddev-deno/actions/workflows/tests.yml/badge.svg)](https://github.com/OpenForgeProject/ddev-deno/actions/workflows/tests.yml)
+[![tests](https://github.com/OpenForgeProject/ddev-deno/actions/workflows/tests.yml/badge.svg?commit=<commit-sha>)](https://github.com/OpenForgeProject/ddev-deno/actions/workflows/tests.yml)
 ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 ## What is Deno?


### PR DESCRIPTION
Fixes #4

Pin the third-party action in `.github/workflows/tests.yml` to a specific commit SHA.

* Update the badge URL in `README.md` to reflect the new commit SHA.
* Replace `ddev/github-action-add-on-test@v2` with `ddev/github-action-add-on-test@<commit-sha>` in `.github/workflows/tests.yml`.

